### PR TITLE
Break run command on empty text.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -152,7 +152,7 @@ function console.run(opt)
         coroutine.yield(0.1)
         text = proc:read_stdout()
 
-        if (text and #text == 0 and not proc:running()) then break; end
+        if text and #text == 0 and not proc:running() then break end
       end
       if output[#output].text ~= "" then
         push_output("\n", opt)

--- a/init.lua
+++ b/init.lua
@@ -152,7 +152,7 @@ function console.run(opt)
         coroutine.yield(0.1)
         text = proc:read_stdout()
 
-        if (text and #text == 0) then break; end
+        if (text and #text == 0 and not proc:running()) then break; end
       end
       if output[#output].text ~= "" then
         push_output("\n", opt)

--- a/init.lua
+++ b/init.lua
@@ -151,6 +151,8 @@ function console.run(opt)
         push_output(text, opt)
         coroutine.yield(0.1)
         text = proc:read_stdout()
+
+        if (text and #text == 0) then break; end
       end
       if output[#output].text ~= "" then
         push_output("\n", opt)


### PR DESCRIPTION
I was having a problem with a batch script that ended with a command with no output. This would cause the console to become unresponsive. The issue was that the while loop this pr modifies would never end in that case, since there was always text but it was empty. 

This fixes the issue. 